### PR TITLE
fix: Display keystatuseschange.expiration as a Date

### DIFF
--- a/eme-trace-config.js
+++ b/eme-trace-config.js
@@ -336,6 +336,14 @@ function getSerializable(obj) {
     if (k.startsWith('__TraceAnything') || typeof obj[k] == 'function') {
       continue;
     }
+
+    // 'keystatuseschange.expiration' is returned as a ECMAScript Time Value,
+    // so convert it into a Date if specified for better readability.
+    if (k == 'expiration' && !isNaN(obj[k])) {
+      clone[k] = getSerializable(new Date(obj[k]));
+      continue;
+    }
+
     clone[k] = getSerializable(obj[k]);
   }
   // Make sure generated IDs get logged.  Do this through a synthetic field.


### PR DESCRIPTION
The values is the number of milliseconds from epoch which isn't
readable, so display it as a Date if possible.

Fixes https://github.com/shaka-project/eme_logger/issues/42