### PR TITLE
fix: Update gulpfile to set image encoding as false

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ function packageExtension() {
     '*.html',
     '*.js',
     '!gulpfile.js',
-  ], {base: './'});
+  ], {base: './', encoding: false});
 
   return sources
       .pipe(rename((path) => {


### PR DESCRIPTION
The EME Logger extension uses gulp to build and package the files, but the icons are not being encoded properly, leading to the error: "Could not decode image". The issue is during Chrome Web Store's upload process, it does not detect this image error, but during the distribution process, the CWS throws errors, and does not update the extension. 

This is caused from gulp jumping over in this commit: https://github.com/shaka-project/eme_logger/commit/a643d50365ab1b355a1b05c2bec16c37760bf073

Now, testing this out, the images are encoded properly, and CWS is able to read it. 