### PR TITLE
fix: Address warning "Unknown project config detect_chromedriver_version"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-detect_chromedriver_version=true


### PR DESCRIPTION
When running npm build, I get the warning:

```
npm warn Unknown env config "detect-chromedriver-version". This will stop working in the next major version of npm.
```

This fixes the warning by removing the detect-chromedriver-version from .npmrc