### PR TITLE
fix: Skip onclick in EME Logger

### DIFF
--- a/eme-trace-config.js
+++ b/eme-trace-config.js
@@ -479,6 +479,7 @@ const EmeLogHelper = {
       'querySelector',
       'querySelectorAll',
       'getVideoPlaybackQuality',
+      'onclick',
     ]),
 
     eventProperties : {


### PR DESCRIPTION
Crbug for reference: https://issues.chromium.org/issues/426451836

Youtube uses onclick for pause and play, and EME logger was disrupting that functionality. With this change, it now works by
adding onclick to the skipProperties list.
