### PR TITLE
build: Update chromedriver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "chromedriver": "^122.0.5",
+    "chromedriver": "^139.0.2",
     "gulp": "^5.0.0",
     "gulp-rename": "^2.0.0",
     "gulp-zip": "^5.1.0",


### PR DESCRIPTION
`npm run test` does not work due to the chromedriver dependency not being set to the latest.

This fixes it by updating the chromedriver version to 139. 
