### PR TITLE
build: Update package-lock for ease of install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,12 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "eme_logger",
       "version": "3.4.3",
       "dependencies": {
         "trace-anything": "^1.0.2"
       },
       "devDependencies": {
-        "chromedriver": "^122.0.5",
+        "chromedriver": "^139.0.2",
         "gulp": "^5.0.0",
         "gulp-rename": "^2.0.0",
         "gulp-zip": "^5.1.0",
@@ -646,15 +645,14 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "122.0.6",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-122.0.6.tgz",
-      "integrity": "sha512-Q0r+QlUtiJWMQ5HdYaFa0CtBmLFq3n5JWfmq9mOC00UMBvWxku09gUkvBt457QnYfTM/XHqY/HTFOxHvATnTmA==",
+      "version": "139.0.2",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-139.0.2.tgz",
+      "integrity": "sha512-GEq1PM9unQBQ79iNxlsJPvMFzcw/LKIusxC39RVD+8noh1JqURNTqbhPGU887VpGUsCFJ0SCSpr+6waK/yWHRA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.6.7",
+        "axios": "^1.7.4",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "proxy-agent": "^6.4.0",
@@ -665,7 +663,7 @@
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/cliui": {


### PR DESCRIPTION
Users will not have to run npm install to resolve any dependency in the package lock.

Tested locally on my linux that a fresh clone does not need npm install.

Otherwise, this error occurs:

`Invalid: lock file's chromedriver@122.0.6 does not satisfy chromedriver@139.0.2`