### PR TITLE
chore: remove trace-anything.js symlink

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,12 +33,17 @@ function packageExtension() {
     'manifest.json',
     '*.html',
     '*.js',
+    'node_modules/trace-anything/trace-anything.js',
     '!gulpfile.js',
   ], {base: './', encoding: false});
 
   return sources
       .pipe(rename((path) => {
-        path.dirname = `eme_logger/${path.dirname}`;
+        if (path.dirname == 'node_modules/trace-anything') {
+          path.dirname = 'eme_logger';
+        } else {
+          path.dirname = `eme_logger/${path.dirname}`;
+        }
       }))
       .pipe(zip(`eme_logger-${version}.zip`))
       .pipe(gulp.dest('.'));

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -2,9 +2,9 @@
   "srcDir": ".",
   "srcFiles": [
     "node_modules/json5/dist/index.js",
+    "node_modules/trace-anything/trace-anything.js",
     "log-window.js",
     "service-worker.js",
-    "trace-anything.js",
     "eme-trace-config.js"
   ],
   "specDir": "spec",

--- a/trace-anything.js
+++ b/trace-anything.js
@@ -1,1 +1,0 @@
-node_modules/trace-anything/trace-anything.js


### PR DESCRIPTION
- Pull trace-anything.js directly from node_modules in gulpfile.js
- Reference trace-anything.js from node_modules in jasmine-browser.json
- Delete the symlink from the root directory

This helps keep agents from getting confused about what sources are in scope for the project, and it's cleaner in general.