### PR TITLE
ci: Add GitHub Actions workflow to test PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,50 @@
+name: Build and Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The ref to build and test."
+        required: false
+        type: string
+
+# If another instance of this workflow is started for the same PR, cancel the
+# old one.  If a PR is updated and a new test run is started, the old test run
+# will be cancelled automatically to conserve resources.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || inputs.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Run compiler
+        run: npm run build
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests
+        run: xvfb-run -a npm test

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   },
   "scripts": {
     "build": "npm ci && gulp",
-    "test": "npx webdriver-installer drivers && PATH=$PATH:drivers jasmine-browser-runner runSpecs",
-    "serve": "npx webdriver-installer drivers && PATH=$PATH:drivers jasmine-browser-runner serve",
+    "install-drivers": "mkdir -p drivers && npx webdriver-installer drivers",
+    "test": "npm run install-drivers && PATH=$PATH:drivers jasmine-browser-runner runSpecs",
+    "serve": "npm run install-drivers && PATH=$PATH:drivers jasmine-browser-runner serve",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },


### PR DESCRIPTION
- Trigger on pull_request and workflow_dispatch (with ref input)
- Run on ubuntu-latest
- Setup Node.js v20
- Install xvfb for headless browser testing
- Run npm ci, npm run build, npm run lint, and tests using xvfb-run

Some adjustments made by the human author.